### PR TITLE
[Refactor] 공통 컴포넌트 접근성 개선

### DIFF
--- a/src/components/common/Avatar/Avatar.styles.ts
+++ b/src/components/common/Avatar/Avatar.styles.ts
@@ -1,4 +1,4 @@
-import { AvatarSize } from '@/types/common';
+import { AvatarSize } from '@/types';
 import styled from 'styled-components';
 
 export const AvatarBtn = styled.button<{ size: AvatarSize }>`

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -1,5 +1,5 @@
 import * as S from './Avatar.styles';
-import { AvatarProps } from '@/types/common';
+import { AvatarProps } from '@/types';
 import { DEFAULT_PROFILE } from '@/constants';
 
 const Avatar = ({
@@ -9,13 +9,18 @@ const Avatar = ({
   onClick,
 }: AvatarProps) => {
   return (
-    <S.AvatarBtn size={size} onClick={onClick}>
+    <S.AvatarBtn
+      size={size}
+      onClick={onClick}
+      aria-label={`${altText} 프로필 이미지`}
+    >
       <S.AvatarImg
         src={imageUrl ?? DEFAULT_PROFILE}
         alt={altText}
         onError={(e) => {
           e.currentTarget.src = DEFAULT_PROFILE; // 폴백 이미지
         }}
+        aria-hidden="true"
       />
     </S.AvatarBtn>
   );

--- a/src/components/common/Button/Button.styles.ts
+++ b/src/components/common/Button/Button.styles.ts
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { StyledBtnProps, StyledPlusBtnProps } from '@/types/common';
+import { StyledBtnProps, StyledPlusBtnProps } from '@/types';
 import { HiPlus } from 'react-icons/hi';
 
 // 공동 disabled 스타일

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,5 +1,5 @@
 import { StyledBtn, StyledPlusBtn } from './Button.styles';
-import { BtnProps } from '@/types/common';
+import { BtnProps } from '@/types';
 
 export const Button = ({
   color = 'primary',

--- a/src/components/common/Category/Category.tsx
+++ b/src/components/common/Category/Category.tsx
@@ -1,17 +1,39 @@
 import * as S from './Category.styles';
-import { CategoryProps } from '@/types/common';
+import { CategoryProps } from '@/types';
 
-const Category = ({ content, isActive = false, onClick }: CategoryProps) => (
-  <S.Category $isActive={isActive} onClick={onClick}>
-    {content}
-  </S.Category>
-);
+const Category = ({
+  type = 'tab',
+  content,
+  isActive = false,
+  onClick,
+}: CategoryProps) => {
+  // tab으로 사용될 때의 props
+  const tabProps = {
+    role: 'tab',
+    'aria-selected': isActive,
+    'aria-controls': `panel-${content}`,
+    id: `tab-${content}`,
+  };
+  // 정보 표시용으로 사용될 때의 props
+  const markProps = {
+    role: 'button',
+  };
+
+  const props = type === 'tab' ? tabProps : markProps;
+
+  return (
+    <S.Category $isActive={isActive} onClick={onClick} {...props}>
+      {content}
+    </S.Category>
+  );
+};
 
 export default Category;
 
 /**
  * 사용 예시
  * <Category 
+ *  type = 'tab', // 메인 페이지에선 tab, 카테고리 표시 용도는 mark 
     content={categoryContent} 
     // isActive={categoryContent === currCategory}
     // onClick={handleCategoryClick} 

--- a/src/components/common/DeferredLoader/DeferredLoader.tsx
+++ b/src/components/common/DeferredLoader/DeferredLoader.tsx
@@ -2,7 +2,14 @@ import * as S from './DeferredLoader.styles';
 import { useState, useEffect } from 'react';
 
 const Loader = () => {
-  return <S.LoadingContainer />;
+  return (
+    <S.LoadingContainer
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="로딩 중"
+    />
+  );
 };
 
 const DeferredLoader = () => {

--- a/src/components/common/EachPlaylist/EachPlaylist.tsx
+++ b/src/components/common/EachPlaylist/EachPlaylist.tsx
@@ -1,6 +1,6 @@
 import * as S from './EachPlaylist.styles';
 import { Avatar, LikeAndSubscribe } from '@/components/common';
-import { EachPlaylistProps } from '@/types/common';
+import { EachPlaylistProps } from '@/types';
 
 const EachPlaylist = ({
   thumbnailUrl,
@@ -17,21 +17,32 @@ const EachPlaylist = ({
   onSubscribeClick,
 }: EachPlaylistProps) => {
   return (
-    <S.PlayListContainer>
+    <S.PlayListContainer
+      aria-label={`${userName}의 플레이리스트: ${playListTitle}`}
+    >
       <S.ThumbnailWraper>
-        <S.TumbnailLayer1 />
-        <S.TumbnailLayer2 />
-        <S.Tumbnail src={thumbnailUrl} />
-        <S.VideoCntWrapper>
-          <S.VideoIcon />
+        <S.TumbnailLayer1 aria-hidden="true" />
+        <S.TumbnailLayer2 aria-hidden="true" />
+        <S.Tumbnail
+          src={thumbnailUrl}
+          alt={`${playListTitle} 플레이리스트 썸네일`}
+        />
+        <S.VideoCntWrapper aria-label={`동영상 ${videoCnt}개`}>
+          <S.VideoIcon aria-hidden="true" />
           <S.VideoCnt>{videoCnt}</S.VideoCnt>
         </S.VideoCntWrapper>
       </S.ThumbnailWraper>
       <S.PlayListInfo>
         <S.PlayListInfoLeft>
-          <Avatar imageUrl={avatarUrl} size={'small'} />
+          <Avatar
+            imageUrl={avatarUrl}
+            size={'small'}
+            altText={`${userName}의 프로필`}
+          />
           <S.UserName>{userName}</S.UserName>
-          <S.UpdateDate>{updateDate}</S.UpdateDate>
+          <S.UpdateDate aria-label={`업데이트 일자: ${updateDate}`}>
+            {updateDate}
+          </S.UpdateDate>
         </S.PlayListInfoLeft>
         <LikeAndSubscribe
           likeCnt={likeCnt}

--- a/src/components/common/ErrorFallback/ErrorFallback.tsx
+++ b/src/components/common/ErrorFallback/ErrorFallback.tsx
@@ -6,9 +6,11 @@ const ErrorFallback = ({ error }: { error: Error }) => {
   const { resetBoundary } = useErrorBoundary();
 
   return (
-    <S.ErrorContainer>
+    <S.ErrorContainer role="alert" aria-live="assertive" aria-atomic="true">
       <S.ErrorText>에러가 발생했습니다</S.ErrorText>
-      <S.ErrorDetailText>{error.message}</S.ErrorDetailText>
+      <S.ErrorDetailText aria-label="에러 상세 내용">
+        {error.message}
+      </S.ErrorDetailText>
       <Button onClick={resetBoundary}>다시 시도</Button>
     </S.ErrorContainer>
   );

--- a/src/components/common/HashTag/HashTag.tsx
+++ b/src/components/common/HashTag/HashTag.tsx
@@ -1,5 +1,5 @@
 import * as S from './HashTag.styles';
-import { HashTagProps } from '@/types/common';
+import { HashTagProps } from '@/types';
 
 const HashTag = ({ content, onClick }: HashTagProps) => (
   <S.HashTag onClick={onClick} aria-label={`해시태그 ${content}`}>

--- a/src/components/common/HashTag/HashTag.tsx
+++ b/src/components/common/HashTag/HashTag.tsx
@@ -2,7 +2,9 @@ import * as S from './HashTag.styles';
 import { HashTagProps } from '@/types/common';
 
 const HashTag = ({ content, onClick }: HashTagProps) => (
-  <S.HashTag onClick={onClick}>#{content}</S.HashTag>
+  <S.HashTag onClick={onClick} aria-label={`해시태그 ${content}`}>
+    #{content}
+  </S.HashTag>
 );
 
 export default HashTag;

--- a/src/components/common/Icon/Icon.tsx
+++ b/src/components/common/Icon/Icon.tsx
@@ -1,28 +1,40 @@
 import * as S from './Icon.styles';
-import { IconProps } from '@/types/common';
+import { IconProps } from '@/types';
 
 const Icon = ({ type, isActive = false, onClick }: IconProps) => {
+  const getAriaLabel = () => {
+    const labels = {
+      like: `${isActive ? '좋아요 취소' : '좋아요'}`,
+      subscribe: `${isActive ? '구독 취소' : '구독하기'}`,
+      alarm: `${isActive ? '새 알림 있음' : '새 알림 없음'}`,
+      comment: '댓글',
+      cancel: '취소',
+      backward: '뒤로 가기',
+      search: '검색',
+    };
+    return labels[type];
+  };
   const iconMap = {
     like: isActive ? (
-      <S.HeartIconFilled onClick={onClick} />
+      <S.HeartIconFilled onClick={onClick} aria-label={getAriaLabel()} />
     ) : (
-      <S.HeartIconEmpty onClick={onClick} />
+      <S.HeartIconEmpty onClick={onClick} aria-label={getAriaLabel()} />
     ),
     subscribe: isActive ? (
-      <S.SubscribeFilled onClick={onClick} />
+      <S.SubscribeFilled onClick={onClick} aria-label={getAriaLabel()} />
     ) : (
-      <S.SubscribeEmpty onClick={onClick} />
+      <S.SubscribeEmpty onClick={onClick} aria-label={getAriaLabel()} />
     ),
     alarm: (
       <S.AlarmIconWrapper>
-        <S.AlarmIcon onClick={onClick} />
-        {isActive && <S.AlarmDot />}
+        <S.AlarmIcon onClick={onClick} aria-label={getAriaLabel()} />
+        {isActive && <S.AlarmDot aria-hidden="true" />}
       </S.AlarmIconWrapper>
     ),
-    comment: <S.CommentIcon onClick={onClick} />,
-    cancel: <S.CancleIcon onClick={onClick} />,
-    backward: <S.BackwardIcon onClick={onClick} />,
-    search: <S.SearchIcon onClick={onClick}></S.SearchIcon>,
+    comment: <S.CommentIcon onClick={onClick} aria-label={getAriaLabel()} />,
+    cancel: <S.CancleIcon onClick={onClick} aria-label={getAriaLabel()} />,
+    backward: <S.BackwardIcon onClick={onClick} aria-label={getAriaLabel()} />,
+    search: <S.SearchIcon onClick={onClick} aria-label={getAriaLabel()} />,
   };
 
   return iconMap[type];

--- a/src/components/common/Input/Input.styles.ts
+++ b/src/components/common/Input/Input.styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { FloatingLabelProps, StyledInputProps } from '@/types/common';
+import { FloatingLabelProps, StyledInputProps } from '@/types';
 
 export const InputWrapper = styled.div`
   position: relative;

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,9 +1,10 @@
 import * as S from './Input.styles';
 import { useState } from 'react';
-import { InputProps } from '@/types/common';
+import { InputProps } from '@/types';
 
 const Input = (props: InputProps) => {
-  const { type, register, errorMessage, label, placeholder, ...rest } = props;
+  const { type, id, register, errorMessage, label, placeholder, ...rest } =
+    props;
   const [isFocused, setIsFocused] = useState(false);
   const [isFilled, setIsFilled] = useState(false);
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -12,15 +13,17 @@ const Input = (props: InputProps) => {
 
   const commonProps = {
     ...register,
+    id,
     $errorMessage: !!errorMessage,
     placeholder: '',
     onFocus: () => setIsFocused(true),
     onBlur: () => setIsFocused(false),
     autoComplete: 'off',
+    'aria-invalid': !!errorMessage,
+    'aria-describedby': errorMessage ? `${id}-error` : undefined,
+    'aria-required': register?.required ? true : undefined,
     ...rest,
   };
-
-  console.log(isFilled, isFocused);
 
   return (
     <>
@@ -29,8 +32,11 @@ const Input = (props: InputProps) => {
       ) : (
         <S.InputWrapper>
           <S.StyledInput type={type} onChange={handleChange} {...commonProps} />
-          <S.ErrorMessage>{errorMessage}</S.ErrorMessage>
+          <S.ErrorMessage id={`${id}-error`} role="alert" aria-live="polite">
+            {errorMessage}
+          </S.ErrorMessage>
           <S.FloatingLabel
+            htmlFor={id}
             $isActive={isFocused || isFilled}
             $errorMessage={!!errorMessage}
           >

--- a/src/components/common/LikeAndSubscribe/LikeAndSubscribe.tsx
+++ b/src/components/common/LikeAndSubscribe/LikeAndSubscribe.tsx
@@ -1,5 +1,5 @@
 import * as S from './LikeAndSubscribe.styles';
-import { LikeAndSubscribeProps } from '@/types/common';
+import { LikeAndSubscribeProps } from '@/types';
 import { Icon } from '@/components/common';
 
 const LikeAndSubscribe = ({
@@ -12,11 +12,11 @@ const LikeAndSubscribe = ({
 }: LikeAndSubscribeProps) => {
   return (
     <S.IconContainer>
-      <S.Iconwapper>
+      <S.Iconwapper aria-label={`좋아요 ${likeCnt}개`}>
         <Icon type="like" isActive={isLiked} onClick={onLikeClick} />
         <S.Cnt>{likeCnt}</S.Cnt>
       </S.Iconwapper>
-      <S.Iconwapper>
+      <S.Iconwapper aria-label={`구독 ${subscribeCnt}개`}>
         <Icon
           type="subscribe"
           isActive={isSubscribed}

--- a/src/components/common/Search/Search.tsx
+++ b/src/components/common/Search/Search.tsx
@@ -1,26 +1,58 @@
 import * as S from './Search.styles';
-import { useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useQueryState } from 'nuqs';
 import { Icon } from '@/components/common';
-import { SearchProps } from '@/types/common';
+import { SearchProps } from '@/types';
 
 const Search = ({
   queryKey,
   placeholder = '사용자, 플레이리스트를 검색해보세요',
 }: SearchProps) => {
   const [query, setQuery] = useQueryState(queryKey);
+  const [inputValue, setInputValue] = useState(query ?? '');
   const inputRef = useRef<HTMLInputElement>(null);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setInputValue(value); // input 값은 즉시 업데이트
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setQuery(value); // URL 쿼리 업데이트는 입력 끝나고 300ms 후에
+    }, 300);
+  };
+
+  const handleSearchIconClick = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setQuery(inputValue); // 현재 input 값으로 즉시 쿼리 업데이트
+  };
 
   return (
-    <S.SearchContainer>
+    <S.SearchContainer role="search" aria-label="검색">
       <S.SearchInput
-        type="text"
+        id="search-input"
+        type="search"
         ref={inputRef}
         value={query ?? ''}
-        onChange={(e) => setQuery(e.target.value)}
+        onChange={handleChange}
         placeholder={placeholder}
+        aria-label="검색어 입력"
       />
-      <Icon type="search" />
+      <Icon type="search" onClick={handleSearchIconClick} />
     </S.SearchContainer>
   );
 };

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -1,5 +1,5 @@
 import * as S from './Select.styles';
-import { SelectProps } from '@/types/common';
+import { SelectProps } from '@/types';
 import {
   CATEGORY_OPTIONS,
   SORT_COMMENT_OPTIONS,
@@ -13,11 +13,30 @@ export const Select = ({ type, value, onChange }: SelectProps) => {
     sortComment: createOptions(SORT_COMMENT_OPTIONS),
     sortEtc: createOptions(SORT_ETC_OPTIONS),
   }[type];
+  const labelText = {
+    category: '카테고리 선택',
+    sortComment: '댓글 정렬 방식 선택',
+    sortEtc: '정렬 방식 선택',
+  }[type];
 
   return (
-    <S.Select value={value} onChange={(e) => onChange(e.target.value)}>
-      {options.map(({ value, label }) => (
-        <option key={value} value={value}>
+    <S.Select
+      aria-label={labelText}
+      role="combobox"
+      aria-expanded="true"
+      aria-controls={`${type}-listbox`}
+      aria-activedescendant={`${type}-option-${value}`}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {options.map(({ value: optionValue, label }) => (
+        <option
+          key={optionValue}
+          value={optionValue}
+          id={`${type}-option-${optionValue}`}
+          role="option"
+          aria-selected={value === optionValue}
+        >
           {label}
         </option>
       ))}

--- a/src/components/common/tabs/Tabs.styles.ts
+++ b/src/components/common/tabs/Tabs.styles.ts
@@ -10,7 +10,7 @@ export const ListContainer = styled.header`
   position: relative;
 `;
 
-export const PanelContainer = styled.article`
+export const PanelContainer = styled.section`
   padding: ${({ theme }) => theme.space.sm};
 `;
 

--- a/src/components/common/tabs/Tabs.tsx
+++ b/src/components/common/tabs/Tabs.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import * as S from './Tabs.styles';
 import { TabsContext } from './context/TabsContext';
-import { TabsProps } from '@/types/common';
+import { TabsProps } from '@/types';
 import List from './components/List';
 import Panel from './components/Panel';
 import Trigger from './components/Trigger';

--- a/src/components/common/tabs/components/List.tsx
+++ b/src/components/common/tabs/components/List.tsx
@@ -1,6 +1,6 @@
 import { ListContainer } from '../Tabs.styles';
 import { useTabsContext } from '../context/TabsContext';
-import { TabListProps } from '@/types/common';
+import { TabListProps } from '@/types';
 
 const List = ({ children }: TabListProps) => {
   const { label } = useTabsContext();

--- a/src/components/common/tabs/components/Panel.tsx
+++ b/src/components/common/tabs/components/Panel.tsx
@@ -1,6 +1,6 @@
 import { PanelContainer } from '../Tabs.styles';
 import { useTabsContext } from '../context/TabsContext';
-import { TabPanelProps } from '@/types/common';
+import { TabPanelProps } from '@/types';
 
 const Panel = ({ value, children }: TabPanelProps) => {
   const { selectedIndex, label } = useTabsContext();

--- a/src/components/common/tabs/components/Trigger.tsx
+++ b/src/components/common/tabs/components/Trigger.tsx
@@ -1,5 +1,5 @@
 import { Btn, TabText } from '../Tabs.styles';
-import { TabTriggerProps } from '@/types/common';
+import { TabTriggerProps } from '@/types';
 import { useTabsContext } from '../context/TabsContext';
 
 const Trigger = ({ value, text }: TabTriggerProps) => {

--- a/src/components/common/tabs/context/TabsContext.tsx
+++ b/src/components/common/tabs/context/TabsContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import { TabsContextType } from '@/types/common';
+import { TabsContextType } from '@/types';
 
 export const TabsContext = createContext<TabsContextType | null>(null);
 

--- a/src/styles/mediaQuery.ts
+++ b/src/styles/mediaQuery.ts
@@ -1,5 +1,5 @@
 import { css } from 'styled-components';
-import { CSSValue, MediaQueryProps } from '@/types/style';
+import { CSSValue, MediaQueryProps } from '@/types';
 
 const breakpoints: MediaQueryProps = {
   mobile: 420,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -34,6 +34,7 @@ export interface HashTagProps {
 
 // Category
 export interface CategoryProps {
+  type?: 'tab' | 'mark'; // 용도 구분 - 메인 페이지 | 플레이리스트아이템
   content: string;
   isActive?: boolean;
   onClick?: () => void;
@@ -151,6 +152,7 @@ export interface EachPlaylistProps {
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
   type: 'text' | 'textarea' | 'email' | 'password';
+  id: string;
   register?: UseFormRegisterReturn;
   errorMessage: string;
   placeholder: string;
@@ -162,6 +164,7 @@ export interface StyledInputProps {
 }
 
 export interface FloatingLabelProps extends StyledInputProps {
+  htmlFor: string;
   $errorMessage: boolean;
   $isActive: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './common';
+export * from './style';


### PR DESCRIPTION
## #️⃣ 연결할 이슈

- 이슈 #13 

## 🧑‍💻 작업 내용

- 각 공통 컴포넌트에 aria-label, role, id 등 접근성 개선을 위한 props를 추가했습니다.

다른 컴포넌트는 사용법이 변한게 없으나
`Categoty`의 경우 tab 역할도 하기 때문에 조금 수정됐습니다.

```js
export interface CategoryProps {
  type?: 'tab' | 'mark'; // 추가됨 - 용도 구분: 메인 페이지 | 플레이리스트아이템
  content: string;
  isActive?: boolean;
  onClick?: () => void;
}
```

그리고 `메인페이지`에서 쓰는 경우
하위 패널(Each Playlist container)에
id={`panel-${content}`}, 
role=“tabpanel”
aria-labelledby={`$trigger-${content}`}
추가해 주셔야합니다.
src/components/common/tabs 와 비슷한 패턴입니다.

## 💾 작업 내용 첨부 (선택 사항)


## 💬 리뷰 요구사항 (선택 사항)
