### PR TITLE
[Feature] errorBoundary, suspense 추가

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,1 @@
+export { default as queryClient } from './react-query';

--- a/src/apis/react-query.ts
+++ b/src/apis/react-query.ts
@@ -1,0 +1,26 @@
+import { QueryClient, QueryCache } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 1000 * 60 * 5,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+      refetchOnMount: true,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+  queryCache: new QueryCache({
+    // 백그라운드 리페치 alert로 표시
+    onError: (error, query) => {
+      if (query.state.data !== undefined) {
+        alert(`에러가 발생했습니다: ${error.message}`);
+      }
+    },
+  }),
+});
+
+export default queryClient;

--- a/src/components/common/ErrorFallback/ErrorFallback.styles.ts
+++ b/src/components/common/ErrorFallback/ErrorFallback.styles.ts
@@ -20,3 +20,25 @@ export const ErrorText = styled.h1`
 export const ErrorDetailText = styled.p`
   font-size: ${({ theme }) => theme.fontSize.lg};
 `;
+
+export const RetryBtn = styled.button`
+  position: relative;
+  color: ${({ theme }) => theme.colors.white};
+  padding: ${({ theme }) => theme.space.sm};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  background-color: ${({ theme }) => theme.colors.gray.extraLight};
+  transition: background-color 0.3s;
+  &:hover {
+    overflow: hidden;
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: ${({ theme }) => theme.colors.opacity.darken1};
+      pointer-events: none;
+    }
+  }
+`;

--- a/src/components/common/ErrorFallback/ErrorFallback.tsx
+++ b/src/components/common/ErrorFallback/ErrorFallback.tsx
@@ -1,6 +1,5 @@
 import * as S from './ErrorFallback.styles';
 import { useErrorBoundary } from 'react-error-boundary';
-import { Button } from '@/components/common';
 
 const ErrorFallback = ({ error }: { error: Error }) => {
   const { resetBoundary } = useErrorBoundary();
@@ -9,7 +8,7 @@ const ErrorFallback = ({ error }: { error: Error }) => {
     <S.ErrorContainer>
       <S.ErrorText>에러가 발생했습니다</S.ErrorText>
       <S.ErrorDetailText>{error.message}</S.ErrorDetailText>
-      <Button onClick={resetBoundary}>다시 시도</Button>
+      <S.RetryBtn onClick={resetBoundary}> 다시 시도 </S.RetryBtn>
     </S.ErrorContainer>
   );
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
 export * from './common';
-export { default as Layout } from './layout/Layout';
+export { Layout, AuthLayout } from './layout/Layout';
 export { default as Home } from './home/Home';
 export { default as User } from './user/User';

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,25 +1,26 @@
 import Header from '@/components/layout/Header/Header';
 import Nav from '@/components/layout/Nav/Nav';
 import { Outlet } from 'react-router-dom';
-import { ThemeProvider } from 'styled-components';
-import { theme } from '@/styles/theme';
-import GlobalStyles from '@/styles/GlobalStyles';
-import '@/styles/fonts.css';
 import * as S from './Layout.styles';
 
-const Layout = () => {
+export const Layout = () => {
   return (
     <main>
-      <ThemeProvider theme={theme}>
-        <GlobalStyles />
-        <Header />
-        <S.OutletContainer>
-          <Outlet />
-        </S.OutletContainer>
-        <Nav />
-      </ThemeProvider>
+      <Header />
+      <S.OutletContainer>
+        <Outlet />
+      </S.OutletContainer>
+      <Nav />
     </main>
   );
 };
 
-export default Layout;
+export const AuthLayout = () => {
+  return (
+    <main>
+      <S.OutletContainer>
+        <Outlet />
+      </S.OutletContainer>
+    </main>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,31 +1,37 @@
-import { StrictMode } from 'react';
+import { StrictMode, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import router from '@/routes/router.tsx';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  QueryClientProvider,
+  QueryErrorResetBoundary,
+} from '@tanstack/react-query';
+import { queryClient } from './apis';
+import { ErrorBoundary } from 'react-error-boundary';
 import { NuqsAdapter } from 'nuqs/adapters/react-router/v7';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      staleTime: 1000 * 60 * 5,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: true,
-      refetchOnMount: true,
-    },
-    mutations: {
-      retry: 0,
-    },
-  },
-});
+import { DeferredLoader, ErrorFallback } from './components';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '@/styles/theme';
+import GlobalStyles from '@/styles/GlobalStyles';
+import '@/styles/fonts.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <NuqsAdapter>
-        <RouterProvider router={router} />
-      </NuqsAdapter>
-    </QueryClientProvider>
+    <ThemeProvider theme={theme}>
+      <GlobalStyles />
+      <QueryClientProvider client={queryClient}>
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary onReset={reset} FallbackComponent={ErrorFallback}>
+              <NuqsAdapter>
+                <Suspense fallback={<DeferredLoader />}>
+                  <RouterProvider router={router} />
+                </Suspense>
+              </NuqsAdapter>
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
+      </QueryClientProvider>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,5 +1,13 @@
+import { Button } from '@/components';
 const HomePage = () => {
-  return <div>HomePage</div>;
+  return (
+    <>
+      <Button color="primary" borderType="round" size="small" disabled={false}>
+        팔로우
+      </Button>
+      <div>HomePage</div>
+    </>
+  );
 };
 
 export default HomePage;

--- a/src/pages/NotFoundPage/NotFoundPage.styles.ts
+++ b/src/pages/NotFoundPage/NotFoundPage.styles.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+export const NotFoundContainer = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Inner = styled.div`
+  text-align: center;
+  width: 80%;
+`;
+
+export const Title = styled.h1`
+  font-size: ${({ theme }) => theme.fontSize.lg};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+`;
+
+export const Description = styled.p`
+  margin: ${({ theme }) => theme.space.lg} 0;
+`;

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,5 +1,35 @@
-const NotFoundPage = () => {
-  return <div>NotFoundPage</div>;
+import * as S from './NotFoundPage.styles';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components';
+
+const NotFound = () => {
+  const navigate = useNavigate();
+
+  const handleToHome = useCallback(() => {
+    navigate('/', { replace: true }); // 홈으로 이동하면서 히스토리 스택을 덮어씀
+  }, [navigate]);
+
+  return (
+    <S.NotFoundContainer>
+      <S.Inner>
+        <S.Title>PAGE NOT FOUND</S.Title>
+        <S.Description>
+          페이지의 주소가 잘못 입력되었거나,
+          <br />
+          요청하신 페이지의 주소가 변경 혹은 삭제되어 찾을 수 없습니다.
+        </S.Description>
+        <Button
+          color="gray"
+          size="small"
+          onClick={handleToHome}
+          aria-label="홈으로 이동"
+        >
+          홈으로
+        </Button>
+      </S.Inner>
+    </S.NotFoundContainer>
+  );
 };
 
-export default NotFoundPage;
+export default NotFound;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
-import { Layout } from '@/components';
+import { Layout, AuthLayout } from '@/components';
 import {
   AlertPage,
   HomePage,
@@ -15,9 +15,11 @@ import {
   MyInfoEditPage,
   UserFollowPage,
   UserPage,
+  NotFoundPage,
 } from '@/pages';
 import { ROUTES } from '@/constants';
-import NotFoundPage from '@/pages/NotFoundPage/NotFoundPage';
+import { ErrorBoundary } from 'react-error-boundary';
+import { ErrorFallback } from '@/components';
 
 const {
   HOME,
@@ -38,10 +40,25 @@ const {
 } = ROUTES;
 
 const router = createBrowserRouter([
-  { path: SIGN_IN, element: <SignInPage /> },
-  { path: SIGN_UP, element: <SignUpPage /> },
   {
-    element: <Layout />,
+    element: (
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <AuthLayout />
+      </ErrorBoundary>
+    ),
+    errorElement: <NotFoundPage />,
+    children: [
+      { path: SIGN_IN, element: <SignInPage /> },
+      { path: SIGN_UP, element: <SignUpPage /> },
+    ],
+  },
+  {
+    element: (
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Layout />
+      </ErrorBoundary>
+    ),
+    errorElement: <NotFoundPage />,
     children: [
       { path: HOME, element: <HomePage /> },
       { path: ALERT, element: <AlertPage /> },


### PR DESCRIPTION
## #️⃣ 연결할 이슈

- 이슈 #17 

## 🧑‍💻 작업 내용

errorBoundary와 suspense 추가 했습니다.
렌더링 중 발생하는 에러
라이프사이클 메서드 에러
생성자(constructor) 에러
자식 컴포넌트 트리에서 발생하는 에러, 라우터 에러는 에러 바운더리가 잡아 화면에 표시하고, 재시도 버튼과 홈으로 가는 버튼을 제공합니다.
tanstack-query와 쓰는 방법은 페이지 작업 후 공유하겠습니다.

## 💾 작업 내용 첨부 (선택 사항)

<img width="1014" alt="스크린샷 2025-01-08 오후 12 40 43" src="https://github.com/user-attachments/assets/6f6e297b-8208-4168-ad7b-041c24604d90" />

<img width="520" alt="스크린샷 2025-01-08 오후 12 13 45" src="https://github.com/user-attachments/assets/6d9cf99c-e223-4da6-a311-8ff962536622" />

## 💬 리뷰 요구사항 (선택 사항)
