### PR TITLE
[Feature] 메인페이지 무한스크롤, 로그인한 유저의 좋아요/구독 플레이리스트 조회 추가

### DIFF
--- a/src/components/layout/Header/Header.styles.ts
+++ b/src/components/layout/Header/Header.styles.ts
@@ -11,7 +11,7 @@ export const HeaderContainer = styled.header.withConfig({
   top: ${({ $show }) => ($show ? '0' : 'calc(-2 * var(--header-height))')};
   left: 0;
   right: 0;
-  padding: 0 ${({ theme }) => theme.space.md};
+  padding: 0 ${({ theme }) => theme.space.md} ${({ theme }) => theme.space.sm};
   background: ${({ theme }) => theme.colors.background};
   z-index: 2;
   transition: 0.5s;

--- a/src/hooks/ui/useShowHeader.ts
+++ b/src/hooks/ui/useShowHeader.ts
@@ -1,9 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/hooks';
+import { useLocation } from 'react-router-dom';
+import { ROUTES } from '@/constants';
 
 const useShowHeader = () => {
   const [showHeader, setShowHeader] = useState(true);
   const lastScrollY = useRef(0);
+  const { pathname } = useLocation();
+  const { HOME } = ROUTES;
 
   const { user } = useAuth();
 
@@ -18,17 +22,21 @@ const useShowHeader = () => {
     const handleScroll = () => {
       const currentScrollY = scrollTarget?.scrollTop || 0;
 
-      if (currentScrollY) {
-        // 스크롤 내릴 때 헤더 숨기기
-        if (currentScrollY > lastScrollY.current) {
-          setShowHeader(false);
-        }
-        // 스크롤 올릴 때 헤더 보이기
-        else {
-          setShowHeader(true);
-        }
+      if (pathname === HOME) {
+        if (currentScrollY) {
+          // 스크롤 내릴 때 헤더 숨기기
+          if (currentScrollY > lastScrollY.current) {
+            setShowHeader(false);
+          }
+          // 스크롤 올릴 때 헤더 보이기
+          else {
+            setShowHeader(true);
+          }
 
-        lastScrollY.current = currentScrollY;
+          lastScrollY.current = currentScrollY;
+        }
+      } else {
+        setShowHeader(true);
       }
     };
 
@@ -37,7 +45,7 @@ const useShowHeader = () => {
     return () => {
       scrollTarget?.removeEventListener('scroll', handleScroll);
     };
-  }, [user, showHeader]);
+  }, [user, showHeader, pathname]);
 
   return showHeader;
 };

--- a/src/hooks/usePlaylist.ts
+++ b/src/hooks/usePlaylist.ts
@@ -127,7 +127,7 @@ export const useGetPlayListByCategory = (
   return { data, isLoading, error, hasMore };
 };
 
-export const getLikedPlaylistById = async (
+export const getLikedPlaylistByUserId = async (
   userId?: string,
   maxCount: number = 5,
 ): Promise<Database['public']['Tables']['PLAYLISTS']['Row'][]> => {
@@ -153,6 +153,63 @@ export const getLikedPlaylistById = async (
       )
       .eq('user_id', userId)
       .not('playlist_id', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(maxCount);
+
+    if (error) throw error;
+
+    if (!data) return [];
+
+    const playlists: Database['public']['Tables']['PLAYLISTS']['Row'][] =
+      data.map((item) => {
+        const playlist = Array.isArray(item.playlist_id)
+          ? item.playlist_id[0]
+          : item.playlist_id;
+
+        return {
+          playlist_id: playlist.playlist_id,
+          created_at: playlist.created_at,
+          updated_at: playlist.updated_at,
+          short_intro: playlist.short_intro,
+          title: playlist.title,
+          user_id: playlist.user_id,
+          thumbnail_image: playlist.thumbnail_image,
+          category_id: playlist.category_id,
+        };
+      });
+
+    return playlists;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};
+
+export const getSubscribedPlaylistByUserId = async (
+  userId?: string,
+  maxCount: number = 5,
+): Promise<Database['public']['Tables']['PLAYLISTS']['Row'][]> => {
+  if (!userId) return [];
+
+  try {
+    const { data, error } = await supabase
+      .from('SUBSCRIBES')
+      .select(
+        `
+            subscribe_id,
+            playlist_id!inner (
+              playlist_id,
+              created_at,
+              updated_at,
+              short_intro,
+              title,
+              user_id,
+              thumbnail_image,
+              category_id
+            )
+          `,
+      )
+      .eq('user_id', userId)
       .order('created_at', { ascending: false })
       .limit(maxCount);
 

--- a/src/hooks/usePlaylist.ts
+++ b/src/hooks/usePlaylist.ts
@@ -126,3 +126,61 @@ export const useGetPlayListByCategory = (
 
   return { data, isLoading, error, hasMore };
 };
+
+export const getLikedPlaylistById = async (
+  userId?: string,
+  maxCount: number = 5,
+): Promise<Database['public']['Tables']['PLAYLISTS']['Row'][]> => {
+  if (!userId) return [];
+
+  try {
+    const { data, error } = await supabase
+      .from('LIKES')
+      .select(
+        `
+            likes_id,
+            playlist_id!inner (
+              playlist_id,
+              created_at,
+              updated_at,
+              short_intro,
+              title,
+              user_id,
+              thumbnail_image,
+              category_id
+            )
+          `,
+      )
+      .eq('user_id', userId)
+      .not('playlist_id', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(maxCount);
+
+    if (error) throw error;
+
+    if (!data) return [];
+
+    const playlists: Database['public']['Tables']['PLAYLISTS']['Row'][] =
+      data.map((item) => {
+        const playlist = Array.isArray(item.playlist_id)
+          ? item.playlist_id[0]
+          : item.playlist_id;
+
+        return {
+          playlist_id: playlist.playlist_id,
+          created_at: playlist.created_at,
+          updated_at: playlist.updated_at,
+          short_intro: playlist.short_intro,
+          title: playlist.title,
+          user_id: playlist.user_id,
+          thumbnail_image: playlist.thumbnail_image,
+          category_id: playlist.category_id,
+        };
+      });
+
+    return playlists;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};

--- a/src/hooks/usePlaylist.ts
+++ b/src/hooks/usePlaylist.ts
@@ -1,3 +1,4 @@
+import { supabase } from '@/apis';
 import { API_ENDPOINTS, QUERY_KEYS } from '@/constants';
 import {
   useCreateData,
@@ -8,6 +9,7 @@ import {
   useUpdateDataByTwoId,
 } from '@/hooks/useSupabaseCrud';
 import type { Database } from '@/types';
+import { useEffect, useState } from 'react';
 
 const { PLAYLISTS } = API_ENDPOINTS;
 const playlistsQueryKey = QUERY_KEYS.PLAYLISTS;
@@ -58,3 +60,69 @@ export const useUpdatePlaylistByIdAndUserId = () =>
 
 export const useDeletePlaylistByIdAndUserId = () =>
   useDeleteDataByTwoId([playlistsQueryKey], PLAYLISTS.BY_ID_AND_USER_ID);
+
+export const useGetPlayListByCategory = (
+  categoryId: string | null,
+  page: number = 1,
+  itemCount: number = 5,
+) => {
+  const [data, setData] = useState<
+    Database['public']['Tables']['PLAYLISTS']['Row'][]
+  >([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+
+  useEffect(() => {
+    const fetchPlayList = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const fromIndex = (page - 1) * itemCount;
+        const toIndex = fromIndex + itemCount - 1;
+
+        const query = supabase
+          .from('PLAYLISTS')
+          .select('*')
+          .order('created_at', { ascending: false })
+          .range(fromIndex, toIndex);
+
+        if (categoryId) {
+          query.eq('category_id', categoryId);
+        }
+
+        const { data: fetchedData, error } = await query;
+        if (error) throw error;
+
+        setData((prevData) => {
+          const combined = [...prevData, ...(fetchedData || [])];
+          const unique = Array.from(
+            new Map(combined.map((item) => [item.playlist_id, item])).values(),
+          );
+          return unique;
+        });
+        setHasMore(fetchedData.length === itemCount);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err
+            : new Error('알 수 없는 오류가 발생했습니다.'),
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPlayList();
+  }, [categoryId, page, itemCount]);
+
+  useEffect(() => {
+    // 새로운 카테고리를 선택했거나 첫 페이지일 경우 데이터 초기화
+    if (page === 1) {
+      setData([]);
+    }
+  }, [categoryId, page]);
+
+  return { data, isLoading, error, hasMore };
+};

--- a/src/pages/HomePage/HomePage.styles.ts
+++ b/src/pages/HomePage/HomePage.styles.ts
@@ -10,7 +10,6 @@ export const PlayListSet = styled.div`
   gap: ${({ theme }) => theme.space.sm};
   overflow: auto;
   white-space: nowrap;
-  margin-bottom: ${({ theme }) => theme.space.lg};
 
   &::-webkit-scrollbar {
     display: none;
@@ -19,10 +18,16 @@ export const PlayListSet = styled.div`
 
 export const PlayListSetTitle = styled.div`
   font-size: ${({ theme }) => theme.fontSize.md};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  margin-bottom: ${({ theme }) => theme.space.sm};
+`;
+
+export const MainPlayLists = styled.div`
+  margin-top: ${({ theme }) => theme.space.lg};
 `;
 
 export const OnePlayList = styled.div`
   margin-bottom: ${({ theme }) => theme.space.lg};
 `;
 
-export const Loading = styled.div``;
+export const Text = styled.div``;

--- a/src/pages/HomePage/HomePage.styles.ts
+++ b/src/pages/HomePage/HomePage.styles.ts
@@ -24,3 +24,5 @@ export const PlayListSetTitle = styled.div`
 export const OnePlayList = styled.div`
   margin-bottom: ${({ theme }) => theme.space.lg};
 `;
+
+export const Loading = styled.div``;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as S from './HomePage.styles';
-import { useFetchPlaylistByCategoryId } from '@/hooks/usePlaylist';
+import { useGetPlayListByCategory } from '@/hooks/usePlaylist';
 import { useCategoryContext } from '@/components/common/Category/CategoryContext';
 import { useFetchCategoryByCategoryNameEn } from '@/hooks/useCategory';
 import { Database } from '@/types';
@@ -23,15 +23,37 @@ const HomePage = () => {
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
     null,
   );
-  const [playLists, setPlayLists] = useState<
-    Database['public']['Tables']['PLAYLISTS']['Row'][]
-  >([]);
+  const [page, setPage] = useState(1);
+  const {
+    data: playLists,
+    isLoading,
+    error,
+    hasMore,
+  } = useGetPlayListByCategory(selectedCategoryId, page, 5);
+  const observer = useRef<IntersectionObserver | null>(null);
+  const lastElementRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (observer.current) observer.current.disconnect();
+
+    observer.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore) {
+          setPage((prevPage) => prevPage + 1);
+        }
+      },
+      { threshold: 1.0 }, // 요소가 100% 보일 때 트리거
+    );
+
+    if (lastElementRef.current) {
+      observer.current.observe(lastElementRef.current);
+    }
+  }, [isLoading, hasMore]);
 
   const { data: categoryData } = useFetchCategoryByCategoryNameEn(
     currCategory !== 'all' ? currCategory : null,
   );
-  const { data: playListsData } =
-    useFetchPlaylistByCategoryId(selectedCategoryId);
 
   useEffect(() => {
     if (currCategory === 'all') {
@@ -40,12 +62,6 @@ const HomePage = () => {
       setSelectedCategoryId(categoryData[0].category_id);
     }
   }, [currCategory, categoryData]);
-
-  useEffect(() => {
-    if (playListsData) {
-      setPlayLists(playListsData);
-    }
-  }, [playListsData]);
 
   const [playListInfos, setPlayListInfos] = useState<
     Record<
@@ -111,14 +127,6 @@ const HomePage = () => {
     }
   }, [playLists]);
 
-  const handleLikeClick = () => {
-    console.log('CLICK LIKE');
-  };
-
-  const handleSubscribeClick = () => {
-    console.log('CLICK SUBSCRIBE');
-  };
-
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleDateString('ko-KR'); // 한국 형식으로 날짜를 표시
@@ -126,7 +134,8 @@ const HomePage = () => {
 
   return (
     <S.HomePageContainer>
-      {playLists?.map((data) => {
+      {playLists?.map((data, idx) => {
+        const isLast = idx === playLists.length - 1;
         const {
           videoCnt,
           likeCnt,
@@ -149,6 +158,7 @@ const HomePage = () => {
         return (
           <S.OnePlayList
             key={data.playlist_id}
+            ref={isLast ? lastElementRef : null}
             onClick={() => navigate(`/playlist/${data.playlist_id}`)}
           >
             <EachPlaylist
@@ -162,12 +172,14 @@ const HomePage = () => {
               isLiked={isLiked}
               isSubscribed={isSubscribed}
               playListTitle={data.title}
-              onLikeClick={handleLikeClick}
-              onSubscribeClick={handleSubscribeClick}
+              onLikeClick={() => {}}
+              onSubscribeClick={() => {}}
             />
           </S.OnePlayList>
         );
       })}
+      {isLoading && <p>Loading...</p>}
+      {error && <p>Error: {error.message}</p>}
     </S.HomePageContainer>
   );
 };

--- a/src/pages/HomePage/LikedPlayList.tsx
+++ b/src/pages/HomePage/LikedPlayList.tsx
@@ -1,68 +1,34 @@
-import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as S from './HomePage.styles';
-import { useGetPlayListByCategory } from '@/hooks/usePlaylist';
-import { useCategoryContext } from '@/components/common/Category/CategoryContext';
-import { useFetchCategoryByCategoryNameEn } from '@/hooks/useCategory';
+import { useEffect, useState } from 'react';
 import { Database } from '@/types';
+import { useAuth, getLikedPlaylistById } from '@/hooks';
 import {
   getIsLiked,
+  getIsSubscribed,
   getLikeCnt,
   getSubscribeCnt,
   getUserInfo,
   getVideoCnt,
-  getIsSubscribed,
 } from '@/services/getEachPlayListInfo';
 import { EachPlaylist } from '@/components';
-import { useNavigate } from 'react-router-dom';
-import { useAuth } from '@/hooks';
-import LikedPlayList from './LikedPlayList';
 
-const HomePage = () => {
+const LikedPlayList = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { currCategory } = useCategoryContext();
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
-    null,
-  );
-  const [page, setPage] = useState(1);
-  const {
-    data: playLists,
-    isLoading,
-    error,
-    hasMore,
-  } = useGetPlayListByCategory(selectedCategoryId, page, 5);
-  const observer = useRef<IntersectionObserver | null>(null);
-  const lastElementRef = useRef<HTMLDivElement | null>(null);
+  const [playLists, setPlayLists] = useState<
+    Database['public']['Tables']['PLAYLISTS']['Row'][]
+  >([]);
 
   useEffect(() => {
-    if (isLoading) return;
-    if (observer.current) observer.current.disconnect();
+    const fetchData = async () => {
+      if (!user?.userId) return;
+      const playlists = await getLikedPlaylistById(user.userId);
+      setPlayLists(playlists);
+    };
 
-    observer.current = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasMore) {
-          setPage((prevPage) => prevPage + 1);
-        }
-      },
-      { threshold: 1.0 }, // 요소가 100% 보일 때 트리거
-    );
-
-    if (lastElementRef.current) {
-      observer.current.observe(lastElementRef.current);
-    }
-  }, [isLoading, hasMore]);
-
-  const { data: categoryData } = useFetchCategoryByCategoryNameEn(
-    currCategory !== 'all' ? currCategory : null,
-  );
-
-  useEffect(() => {
-    if (currCategory === 'all') {
-      setSelectedCategoryId(null);
-    } else if (categoryData && categoryData.length > 0) {
-      setSelectedCategoryId(categoryData[0].category_id);
-    }
-  }, [currCategory, categoryData]);
+    fetchData();
+  }, [user?.userId]);
 
   const [playListInfos, setPlayListInfos] = useState<
     Record<
@@ -134,16 +100,12 @@ const HomePage = () => {
   };
 
   return (
-    <S.HomePageContainer>
-      {user && (
-        <>
-          <LikedPlayList />
-          <S.PlayListSetTitle>추천 플레이리스트</S.PlayListSetTitle>
-        </>
-      )}
-      <S.MainPlayLists>
-        {playLists?.map((data, idx) => {
-          const isLast = idx === playLists.length - 1;
+    <>
+      <S.PlayListSetTitle onClick={() => navigate(`/like`)}>
+        좋아요한 플레이리스트
+      </S.PlayListSetTitle>
+      <S.PlayListSet>
+        {playLists?.map((data) => {
           const {
             videoCnt,
             likeCnt,
@@ -166,7 +128,6 @@ const HomePage = () => {
           return (
             <S.OnePlayList
               key={data.playlist_id}
-              ref={isLast ? lastElementRef : null}
               onClick={() => navigate(`/playlist/${data.playlist_id}`)}
             >
               <EachPlaylist
@@ -186,14 +147,11 @@ const HomePage = () => {
             </S.OnePlayList>
           );
         })}
-        {isLoading && <S.Text>Loading...</S.Text>}
-        {error && <S.Text>Error: {error.message}</S.Text>}
         {playLists.length === 0 && (
-          <S.Text>해당 카테고리의 플레이리스트가 없습니다.</S.Text>
+          <S.Text>아직 좋아요를 누른 플레이리스트가 없습니다.</S.Text>
         )}
-      </S.MainPlayLists>
-    </S.HomePageContainer>
+      </S.PlayListSet>
+    </>
   );
 };
-
-export default HomePage;
+export default LikedPlayList;

--- a/src/pages/HomePage/LikedPlayList.tsx
+++ b/src/pages/HomePage/LikedPlayList.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import * as S from './HomePage.styles';
 import { useEffect, useState } from 'react';
 import { Database } from '@/types';
-import { useAuth, getLikedPlaylistById } from '@/hooks';
+import { useAuth, getLikedPlaylistByUserId } from '@/hooks';
 import {
   getIsLiked,
   getIsSubscribed,
@@ -23,7 +23,7 @@ const LikedPlayList = () => {
   useEffect(() => {
     const fetchData = async () => {
       if (!user?.userId) return;
-      const playlists = await getLikedPlaylistById(user.userId);
+      const playlists = await getLikedPlaylistByUserId(user.userId);
       setPlayLists(playlists);
     };
 
@@ -148,7 +148,7 @@ const LikedPlayList = () => {
           );
         })}
         {playLists.length === 0 && (
-          <S.Text>아직 좋아요를 누른 플레이리스트가 없습니다.</S.Text>
+          <S.Text>아직 구독한 플레이리스트가 없습니다.</S.Text>
         )}
       </S.PlayListSet>
     </>

--- a/src/pages/HomePage/SubscribedPlayList.tsx
+++ b/src/pages/HomePage/SubscribedPlayList.tsx
@@ -1,69 +1,34 @@
-import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as S from './HomePage.styles';
-import { useGetPlayListByCategory } from '@/hooks/usePlaylist';
-import { useCategoryContext } from '@/components/common/Category/CategoryContext';
-import { useFetchCategoryByCategoryNameEn } from '@/hooks/useCategory';
+import { useEffect, useState } from 'react';
 import { Database } from '@/types';
+import { useAuth, getSubscribedPlaylistByUserId } from '@/hooks';
 import {
   getIsLiked,
+  getIsSubscribed,
   getLikeCnt,
   getSubscribeCnt,
   getUserInfo,
   getVideoCnt,
-  getIsSubscribed,
 } from '@/services/getEachPlayListInfo';
 import { EachPlaylist } from '@/components';
-import { useNavigate } from 'react-router-dom';
-import { useAuth } from '@/hooks';
-import LikedPlayList from './LikedPlayList';
-import SubscribedPlayList from './SubscribedPlayList';
 
-const HomePage = () => {
+const SubscribedPlayList = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { currCategory } = useCategoryContext();
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
-    null,
-  );
-  const [page, setPage] = useState(1);
-  const {
-    data: playLists,
-    isLoading,
-    error,
-    hasMore,
-  } = useGetPlayListByCategory(selectedCategoryId, page, 5);
-  const observer = useRef<IntersectionObserver | null>(null);
-  const lastElementRef = useRef<HTMLDivElement | null>(null);
+  const [playLists, setPlayLists] = useState<
+    Database['public']['Tables']['PLAYLISTS']['Row'][]
+  >([]);
 
   useEffect(() => {
-    if (isLoading) return;
-    if (observer.current) observer.current.disconnect();
+    const fetchData = async () => {
+      if (!user?.userId) return;
+      const playlists = await getSubscribedPlaylistByUserId(user.userId);
+      setPlayLists(playlists);
+    };
 
-    observer.current = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasMore) {
-          setPage((prevPage) => prevPage + 1);
-        }
-      },
-      { threshold: 1.0 }, // 요소가 100% 보일 때 트리거
-    );
-
-    if (lastElementRef.current) {
-      observer.current.observe(lastElementRef.current);
-    }
-  }, [isLoading, hasMore]);
-
-  const { data: categoryData } = useFetchCategoryByCategoryNameEn(
-    currCategory !== 'all' ? currCategory : null,
-  );
-
-  useEffect(() => {
-    if (currCategory === 'all') {
-      setSelectedCategoryId(null);
-    } else if (categoryData && categoryData.length > 0) {
-      setSelectedCategoryId(categoryData[0].category_id);
-    }
-  }, [currCategory, categoryData]);
+    fetchData();
+  }, [user?.userId]);
 
   const [playListInfos, setPlayListInfos] = useState<
     Record<
@@ -135,17 +100,12 @@ const HomePage = () => {
   };
 
   return (
-    <S.HomePageContainer>
-      {user && (
-        <>
-          <LikedPlayList />
-          <SubscribedPlayList />
-          <S.PlayListSetTitle>추천 플레이리스트</S.PlayListSetTitle>
-        </>
-      )}
-      <S.MainPlayLists>
-        {playLists?.map((data, idx) => {
-          const isLast = idx === playLists.length - 1;
+    <>
+      <S.PlayListSetTitle onClick={() => navigate(`/subscribe`)}>
+        구독한 플레이리스트
+      </S.PlayListSetTitle>
+      <S.PlayListSet>
+        {playLists?.map((data) => {
           const {
             videoCnt,
             likeCnt,
@@ -168,7 +128,6 @@ const HomePage = () => {
           return (
             <S.OnePlayList
               key={data.playlist_id}
-              ref={isLast ? lastElementRef : null}
               onClick={() => navigate(`/playlist/${data.playlist_id}`)}
             >
               <EachPlaylist
@@ -188,14 +147,11 @@ const HomePage = () => {
             </S.OnePlayList>
           );
         })}
-        {isLoading && <S.Text>Loading...</S.Text>}
-        {error && <S.Text>Error: {error.message}</S.Text>}
         {playLists.length === 0 && (
-          <S.Text>해당 카테고리의 플레이리스트가 없습니다.</S.Text>
+          <S.Text>아직 좋아요를 누른 플레이리스트가 없습니다.</S.Text>
         )}
-      </S.MainPlayLists>
-    </S.HomePageContainer>
+      </S.PlayListSet>
+    </>
   );
 };
-
-export default HomePage;
+export default SubscribedPlayList;


### PR DESCRIPTION
## #️⃣ 연결할 이슈

- 이슈 #62 

## 🧑‍💻 작업 내용

- 무한스크롤 구현
- 로그인한 유저의 좋아요/구독 플레이리스트 추가
- 스크롤 내려서 헤더 사라진 후 다른 페이지 진입시 여전히 헤더가 사라져 있는 에러 수정

## 💾 작업 내용 첨부 (선택 사항)
![image](https://github.com/user-attachments/assets/6810818d-3aff-4043-8ab8-92908c616a05)

## 💬 리뷰 요구사항 (선택 사항)

> 리뷰 요구사항을 작성해주세요.

- 
